### PR TITLE
[RF] Fix shadow warning in RooTemplateProxy.

### DIFF
--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -134,9 +134,9 @@ private:
 #ifdef NDEBUG
     return static_cast<RooAbsRealLValue*>(_arg);
 #else
-    auto arg = dynamic_cast<RooAbsRealLValue*>(_arg);
-    assert(arg);
-    return arg;
+    auto theArg = dynamic_cast<RooAbsRealLValue*>(_arg);
+    assert(theArg);
+    return theArg;
 #endif
   }
 


### PR DESCRIPTION
Old gcc issues a shadow warning if a local variable and a function have the same name.